### PR TITLE
Fix SCILSDarkSwitching values

### DIFF
--- a/sci-rs/src/scils.rs
+++ b/sci-rs/src/scils.rs
@@ -303,7 +303,8 @@ impl TryFrom<u8> for SCILSDrivewayInformation {
 pub enum SCILSDarkSwitching {
     #[default]
     Show = 0x01,
-    Dark = 0xFF,
+    Dark = 0x0F,
+    NotApplicable = 0xFF,
 }
 
 impl TryFrom<u8> for SCILSDarkSwitching {
@@ -312,7 +313,8 @@ impl TryFrom<u8> for SCILSDarkSwitching {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x01 => Ok(Self::Show),
-            0xFF => Ok(Self::Dark),
+            0x0F => Ok(Self::Dark),
+            0xFF => Ok(Self::NotApplicable),
             v => Err(SciLsError::InvalidDarkSwitching(v).into()),
         }
     }

--- a/sci-rs/src/scils.rs
+++ b/sci-rs/src/scils.rs
@@ -301,9 +301,9 @@ impl TryFrom<u8> for SCILSDrivewayInformation {
 #[derive(Default, Clone, Copy)]
 #[repr(u8)]
 pub enum SCILSDarkSwitching {
-    #[default]
     Show = 0x01,
     Dark = 0x0F,
+    #[default]
     NotApplicable = 0xFF,
 }
 


### PR DESCRIPTION
According to the specification, for SCILSDarkSwitching `0x0F` is "dark", while `0xFF` is "not applicable". This was somehow wrong until now.